### PR TITLE
Checks if batch_scanned_event is initialized before calling .set()

### DIFF
--- a/cornershot/cornershot.py
+++ b/cornershot/cornershot.py
@@ -161,7 +161,7 @@ class CornerShot(object):
                     self.resultQ.task_done()
                     remaining += 1
                     self.total_shots -= 1
-                    if self.total_shots % 500 == 0:
+                    if self.total_shots % 500 == 0 and self.batch_scanned_event is not None:  # skip if blocking == True
                         self.batch_scanned_event.set()
                     if self.total_shots < 1:
                         self.runthreads = False
@@ -169,7 +169,7 @@ class CornerShot(object):
                     break
 
         self.total_shots = 0
-        self.batch_scanned_event.set()
+        self.batch_scanned_event.set() if self.batch_scanned_event is not None else None  # skip if blocking == True
 
     def open_fire(self,blocking=True,skip_scanned=False):
         self.skip_scanned = skip_scanned


### PR DESCRIPTION
Encountered an issue where `batch_scanned_event` would be initialized as `None` and remain in this state when `blocking=True` on [line 174](https://github.com/zeronetworks/cornershot/blob/master/cornershot/cornershot.py#L174). `batch_scanned_event` is only initialized on [line 191](https://github.com/zeronetworks/cornershot/blob/master/cornershot/cornershot.py#L191) if `blocking` is False. Because the object was set to `None`, an AttributeError is raised.

```
...
CornerShot got exception - 'NoneType' object has no attribute 'set'
CornerShot unexpected exception!
Traceback (most recent call last):
  File "/home/ph/.local/lib/python3.8/site-packages/cornershot/__main__.py", line 113, in <module>
    cs.open_fire()
  File "/home/ph/.local/lib/python3.8/site-packages/cornershot/cornershot.py", line 186, in open_fire
    self._shots_manager()
  File "/home/ph/.local/lib/python3.8/site-packages/cornershot/cornershot.py", line 165, in _shots_manager
    self.batch_scanned_event.set()
AttributeError: 'NoneType' object has no attribute 'set'
...
```

Added checks on two lines that reference `batch_scanned_event` to ensure the variable is initialized before using the `.set()` method. Tested Cornershot with this change and the exception is no longer raised. 

Please feel free to reach out if you have any questions; happy to discuss.